### PR TITLE
feat: Add back navigation buttons to documentation pages

### DIFF
--- a/docs/indexing_pipeline.html
+++ b/docs/indexing_pipeline.html
@@ -41,6 +41,32 @@
             font-size: 1.2em;
         }
 
+        .back-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 1em;
+            transition: all 0.3s ease;
+            box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+            margin-bottom: 30px;
+        }
+
+        .back-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
+        }
+
+        .back-button::before {
+            content: '←';
+            font-size: 1.3em;
+        }
+
         .pipeline {
             display: flex;
             flex-direction: column;
@@ -328,6 +354,7 @@
 </head>
 <body>
     <div class="container">
+        <a href="index.html" class="back-button">Back to Home</a>
         <h1>📥 SUJBOT2 Indexing Pipeline</h1>
         <p class="subtitle">Fáze 1-5: Od dokumentu k prohledávatelnému vektorovému indexu (SOTA RAG 2025)</p>
 

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -44,6 +44,32 @@
             margin-bottom: 10px;
         }
 
+        .back-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 1em;
+            transition: all 0.3s ease;
+            box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+            margin-bottom: 30px;
+        }
+
+        .back-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(139, 92, 246, 0.4);
+        }
+
+        .back-button::before {
+            content: '←';
+            font-size: 1.3em;
+        }
+
         .timeline-info {
             color: #4a5568;
             font-size: 1.1em;
@@ -274,6 +300,7 @@
 </head>
 <body>
     <div class="container">
+        <a href="index.html" class="back-button">Back to Home</a>
         <div class="header">
             <h1>🗓️ SUJBOT2 Roadmap</h1>
             <p class="subtitle">4-týdenní plán vylepšení RAG systému</p>

--- a/docs/user_search_pipeline.html
+++ b/docs/user_search_pipeline.html
@@ -41,6 +41,32 @@
             font-size: 1.2em;
         }
 
+        .back-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 1em;
+            transition: all 0.3s ease;
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+            margin-bottom: 30px;
+        }
+
+        .back-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(16, 185, 129, 0.4);
+        }
+
+        .back-button::before {
+            content: '←';
+            font-size: 1.3em;
+        }
+
         .pipeline {
             display: flex;
             flex-direction: column;
@@ -295,6 +321,7 @@
 </head>
 <body>
     <div class="container">
+        <a href="index.html" class="back-button">Back to Home</a>
         <h1>💬 SUJBOT2 User Search Pipeline</h1>
         <p class="subtitle">Phase 7: Od user query k AI odpovědi (Claude SDK Agent + 16 Tools)</p>
 


### PR DESCRIPTION
## Summary
Add navigation back buttons to all HTML documentation pages for better user experience.

## Changes
- **indexing_pipeline.html** - Blue themed back button
- **user_search_pipeline.html** - Green themed back button  
- **roadmap.html** - Purple themed back button

All buttons link back to `index.html` and are positioned at the top-left of each page with hover effects.

## Visual Design
- Consistent styling across all pages
- Color-matched to page theme
- Smooth hover animations
- Left arrow (←) icon prefix

## Testing
- [x] Back buttons render correctly on all pages
- [x] Links navigate to index.html
- [x] Hover effects work properly
- [x] Buttons are visible and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>