### PR TITLE
fix: Add white-space CSS property to preserve code formatting

### DIFF
--- a/docs/indexing_pipeline.html
+++ b/docs/indexing_pipeline.html
@@ -280,6 +280,7 @@
             font-family: 'Courier New', monospace;
             font-size: 0.95em;
             line-height: 1.8;
+            white-space: pre-wrap;
         }
 
         .research-note {

--- a/docs/user_search_pipeline.html
+++ b/docs/user_search_pipeline.html
@@ -260,6 +260,7 @@
             line-height: 1.8;
             margin: 15px 0;
             overflow-x: auto;
+            white-space: pre-wrap;
         }
 
         .code-comment {


### PR DESCRIPTION
## Summary
Fixed CSS formatting in visual documentation where code blocks and CLI examples were displaying incorrectly (text collapsed into single lines). 

## Changes
- Added `white-space: pre-wrap;` to `.code-box` in `user_search_pipeline.html`
- Added `white-space: pre-wrap;` to `.data-flow-content` in `indexing_pipeline.html`

## Before
CLI examples and code blocks were displaying as single collapsed lines without proper line breaks.

## After
Code formatting now properly preserves line breaks and spacing while maintaining text wrapping.

## Test plan
- [x] Opened `docs/user_search_pipeline.html` in browser
- [x] Verified CLI command examples display correctly with line breaks
- [x] Verified code blocks maintain proper formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)