### PR TITLE
fix: revert neo4j config to use fallback pattern

### DIFF
--- a/config.json
+++ b/config.json
@@ -178,9 +178,9 @@
     "enabled_types": null
   },
   "neo4j": {
-    "uri_env": "NEO4J_URI",
-    "username_env": "NEO4J_USER",
-    "password_env": "NEO4J_PASSWORD",
+    "uri": "bolt://localhost:7687",
+    "username": "neo4j",
+    "password": "",
     "database": "neo4j",
     "max_connection_lifetime": 3600,
     "max_connection_pool_size": 50,


### PR DESCRIPTION
## Summary

Fixes the config.json schema issue introduced in PR #153. The previous change broke the Neo4j config validation by using `_env` suffix pattern which is not supported by the schema.

## Changes

- Revert `neo4j.uri_env` → `neo4j.uri` (with placeholder)
- Revert `neo4j.username_env` → `neo4j.username` (with placeholder)
- Revert `neo4j.password_env` → `neo4j.password` (empty string)

## How it works

The code uses env var fallback pattern:
```python
uri = os.getenv("NEO4J_URI", config.get("uri", "bolt://localhost:7687"))
```

This means:
1. Environment variable takes priority (secure)
2. Config.json value is fallback (no secrets stored)
3. Default value if neither set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database connection configuration updated with concrete default parameter values now available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->