### PR TITLE
feat(frontend): add citation hover preview with chunk content

### DIFF
--- a/frontend/src/admin/components/AdminConversationViewer.tsx
+++ b/frontend/src/admin/components/AdminConversationViewer.tsx
@@ -65,7 +65,10 @@ export function AdminConversationViewer({ userId }: AdminConversationViewerProps
     try {
       const response = await fetch(
         `${getApiBaseUrl()}/admin/users/${userId}/conversations`,
-        { credentials: 'include' }
+        {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        }
       );
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
@@ -86,7 +89,10 @@ export function AdminConversationViewer({ userId }: AdminConversationViewerProps
     try {
       const response = await fetch(
         `${getApiBaseUrl()}/admin/users/${userId}/conversations/${conversationId}/messages`,
-        { credentials: 'include' }
+        {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        }
       );
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/frontend/src/components/citation/CitationLink.tsx
+++ b/frontend/src/components/citation/CitationLink.tsx
@@ -52,13 +52,17 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
 
   const metadata = citationCache.get(chunkId);
 
-  // Hover handlers with delay
+  // Unique ID for ARIA tooltip relationship
+  const tooltipId = `citation-preview-${chunkId.replace(/[^a-zA-Z0-9]/g, '-')}`;
+
+  // Hover/focus handlers with delay
   const handleMouseEnter = useCallback((ref: React.RefObject<HTMLElement | null>) => {
     if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
     hoverTimeoutRef.current = setTimeout(() => {
-      setIsHovered(true);
+      // Only show preview if ref is still valid (prevents race condition)
       if (ref.current) {
         setAnchorRect(ref.current.getBoundingClientRect());
+        setIsHovered(true);
       }
     }, HOVER_ENTER_DELAY);
   }, []);
@@ -127,6 +131,7 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
     if (!isHovered || !metadata) return null;
     return createPortal(
       <CitationPreview
+        id={tooltipId}
         metadata={metadata}
         anchorRect={anchorRect}
         onMouseEnter={handlePreviewMouseEnter}
@@ -142,13 +147,19 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
       <>
         <span
           ref={spanRef}
+          tabIndex={0}
+          role="button"
+          aria-describedby={isHovered ? tooltipId : undefined}
           onMouseEnter={() => handleMouseEnter(spanRef)}
           onMouseLeave={handleMouseLeave}
+          onFocus={() => handleMouseEnter(spanRef)}
+          onBlur={handleMouseLeave}
           className={cn(
             'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
             'bg-accent-100 dark:bg-accent-800',
             'text-accent-600 dark:text-accent-400',
-            'text-xs font-mono'
+            'text-xs font-mono',
+            'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1'
           )}
         >
           <FileText size={10} className="opacity-50" />
@@ -164,9 +175,12 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
     <>
       <button
         ref={buttonRef}
+        aria-describedby={isHovered ? tooltipId : undefined}
         onClick={handleClick}
         onMouseEnter={() => handleMouseEnter(buttonRef)}
         onMouseLeave={handleMouseLeave}
+        onFocus={() => handleMouseEnter(buttonRef)}
+        onBlur={handleMouseLeave}
         className={cn(
           'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
           'bg-blue-100 dark:bg-blue-900/40',
@@ -176,7 +190,8 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
           'text-xs font-mono',
           'transition-colors duration-150',
           'cursor-pointer',
-          'border border-blue-200 dark:border-blue-700/50'
+          'border border-blue-200 dark:border-blue-700/50',
+          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1'
         )}
       >
         <FileText size={10} />

--- a/frontend/src/components/citation/CitationLink.tsx
+++ b/frontend/src/components/citation/CitationLink.tsx
@@ -5,21 +5,34 @@
  * Uses the CitationContext to fetch metadata and manage PDF viewer state.
  *
  * Display format: [BZ_VR1:12] (document:page)
- * Tooltip shows: section path or title
+ * Hover shows: rich preview with chunk content
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { FileText, Loader2 } from 'lucide-react';
 import { cn } from '../../design-system/utils/cn';
 import { useCitationContext } from '../../contexts/CitationContext';
-import { formatCitationShort, formatCitationTooltip } from '../../utils/citations';
+import { formatCitationShort } from '../../utils/citations';
+import { CitationPreview } from './CitationPreview';
 
 interface CitationLinkProps {
   chunkId: string;
 }
 
+// Hover delay constants (ms)
+const HOVER_ENTER_DELAY = 200; // Delay before showing preview
+const HOVER_LEAVE_DELAY = 100; // Delay before hiding (allows moving to preview)
+
 export function CitationLink({ chunkId }: CitationLinkProps) {
   const { citationCache, fetchCitationMetadata, openPdf, loadingIds } = useCitationContext();
+
+  // Hover state for preview
+  const [isHovered, setIsHovered] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Fetch metadata on mount if not cached
   useEffect(() => {
@@ -28,7 +41,43 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
     }
   }, [chunkId, citationCache, fetchCitationMetadata]);
 
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const metadata = citationCache.get(chunkId);
+
+  // Hover handlers with delay
+  const handleMouseEnter = useCallback((ref: React.RefObject<HTMLElement | null>) => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(true);
+      if (ref.current) {
+        setAnchorRect(ref.current.getBoundingClientRect());
+      }
+    }, HOVER_ENTER_DELAY);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(false);
+    }, HOVER_LEAVE_DELAY);
+  }, []);
+
+  // Keep preview open when hovering the preview itself
+  const handlePreviewMouseEnter = useCallback(() => {
+    if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+  }, []);
+
+  const handlePreviewMouseLeave = useCallback(() => {
+    setIsHovered(false);
+  }, []);
 
   // Handle click - open PDF side panel
   const handleClick = () => {
@@ -72,45 +121,68 @@ export function CitationLink({ chunkId }: CitationLinkProps) {
   }
 
   const displayText = formatCitationShort(metadata.documentId, metadata.pageNumber);
-  const tooltipText = formatCitationTooltip(metadata.sectionPath, metadata.sectionTitle);
 
-  // PDF not available - show non-clickable badge
+  // Render preview portal helper
+  const renderPreview = () => {
+    if (!isHovered || !metadata) return null;
+    return createPortal(
+      <CitationPreview
+        metadata={metadata}
+        anchorRect={anchorRect}
+        onMouseEnter={handlePreviewMouseEnter}
+        onMouseLeave={handlePreviewMouseLeave}
+      />,
+      document.body
+    );
+  };
+
+  // PDF not available - show non-clickable badge with hover preview
   if (!metadata.pdfAvailable) {
     return (
-      <span
-        className={cn(
-          'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
-          'bg-accent-100 dark:bg-accent-800',
-          'text-accent-600 dark:text-accent-400',
-          'text-xs font-mono'
-        )}
-        title={tooltipText}
-      >
-        <FileText size={10} className="opacity-50" />
-        {displayText}
-      </span>
+      <>
+        <span
+          ref={spanRef}
+          onMouseEnter={() => handleMouseEnter(spanRef)}
+          onMouseLeave={handleMouseLeave}
+          className={cn(
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
+            'bg-accent-100 dark:bg-accent-800',
+            'text-accent-600 dark:text-accent-400',
+            'text-xs font-mono'
+          )}
+        >
+          <FileText size={10} className="opacity-50" />
+          {displayText}
+        </span>
+        {renderPreview()}
+      </>
     );
   }
 
-  // Clickable citation with PDF available
+  // Clickable citation with PDF available and hover preview
   return (
-    <button
-      onClick={handleClick}
-      className={cn(
-        'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
-        'bg-blue-100 dark:bg-blue-900/40',
-        'text-blue-700 dark:text-blue-300',
-        'hover:bg-blue-200 dark:hover:bg-blue-800/60',
-        'hover:text-blue-800 dark:hover:text-blue-200',
-        'text-xs font-mono',
-        'transition-colors duration-150',
-        'cursor-pointer',
-        'border border-blue-200 dark:border-blue-700/50'
-      )}
-      title={tooltipText}
-    >
-      <FileText size={10} />
-      {displayText}
-    </button>
+    <>
+      <button
+        ref={buttonRef}
+        onClick={handleClick}
+        onMouseEnter={() => handleMouseEnter(buttonRef)}
+        onMouseLeave={handleMouseLeave}
+        className={cn(
+          'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
+          'bg-blue-100 dark:bg-blue-900/40',
+          'text-blue-700 dark:text-blue-300',
+          'hover:bg-blue-200 dark:hover:bg-blue-800/60',
+          'hover:text-blue-800 dark:hover:text-blue-200',
+          'text-xs font-mono',
+          'transition-colors duration-150',
+          'cursor-pointer',
+          'border border-blue-200 dark:border-blue-700/50'
+        )}
+      >
+        <FileText size={10} />
+        {displayText}
+      </button>
+      {renderPreview()}
+    </>
   );
 }

--- a/frontend/src/components/citation/CitationPreview.tsx
+++ b/frontend/src/components/citation/CitationPreview.tsx
@@ -1,0 +1,181 @@
+/**
+ * CitationPreview Component
+ *
+ * Floating preview popover shown on citation hover.
+ * Auto-positions above/below based on available viewport space.
+ *
+ * Features:
+ * - Fade in/out animation (respects prefers-reduced-motion)
+ * - Automatic flip positioning
+ * - Max-height with scroll for very long content
+ * - Dark mode support
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { FileText } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../design-system/utils/cn';
+import { usePopoverPosition } from '../../hooks/usePopoverPosition';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { timing } from '../../design-system/tokens/timing';
+import type { CitationMetadata } from '../../types';
+
+interface CitationPreviewProps {
+  metadata: CitationMetadata;
+  anchorRect: DOMRect | null;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+// Popover dimensions
+const POPOVER_WIDTH = 320;
+const POPOVER_MAX_HEIGHT = 300;
+const ESTIMATED_HEIGHT = 200; // Initial estimate for positioning
+
+export function CitationPreview({
+  metadata,
+  anchorRect,
+  onMouseEnter,
+  onMouseLeave,
+}: CitationPreviewProps) {
+  const { t } = useTranslation();
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [actualHeight, setActualHeight] = useState(ESTIMATED_HEIGHT);
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Respect accessibility preferences
+  const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  // Calculate position
+  const position = usePopoverPosition({
+    anchorRect,
+    popoverHeight: actualHeight,
+    popoverWidth: POPOVER_WIDTH,
+    gap: 8,
+  });
+
+  // Measure actual height after render
+  useEffect(() => {
+    if (popoverRef.current) {
+      const height = Math.min(popoverRef.current.scrollHeight, POPOVER_MAX_HEIGHT);
+      setActualHeight(height);
+    }
+  }, [metadata.content]);
+
+  // Fade in animation
+  useEffect(() => {
+    // Small delay for DOM to settle before animation
+    const timer = setTimeout(() => setIsVisible(true), 10);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!position) return null;
+
+  const displayPath = metadata.sectionPath || metadata.hierarchicalPath || metadata.documentName;
+  const hasContent = metadata.content && metadata.content.trim().length > 0;
+
+  return (
+    <div
+      ref={popoverRef}
+      role="tooltip"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={cn(
+        'fixed z-50',
+        'bg-white dark:bg-accent-900',
+        'border border-accent-200 dark:border-accent-700',
+        'rounded-lg shadow-xl',
+        'text-sm',
+        'overflow-hidden'
+      )}
+      style={{
+        top: position.top,
+        left: position.left,
+        width: POPOVER_WIDTH,
+        maxHeight: POPOVER_MAX_HEIGHT,
+        opacity: isVisible ? 1 : 0,
+        transform: isVisible
+          ? 'translateY(0)'
+          : position.placement === 'bottom'
+            ? 'translateY(-4px)'
+            : 'translateY(4px)',
+        transition: prefersReducedMotion
+          ? 'none'
+          : `opacity ${timing.durations.fast} ${timing.easings.easeOut}, transform ${timing.durations.fast} ${timing.easings.easeOut}`,
+      }}
+    >
+      {/* Arrow */}
+      <div
+        className={cn(
+          'absolute w-3 h-3',
+          'bg-white dark:bg-accent-900',
+          'border-accent-200 dark:border-accent-700',
+          'transform rotate-45',
+          position.placement === 'bottom'
+            ? '-top-1.5 border-l border-t'
+            : '-bottom-1.5 border-r border-b'
+        )}
+        style={{ left: position.arrowLeft - 6 }}
+      />
+
+      {/* Header */}
+      <div
+        className={cn(
+          'flex items-center gap-2 px-3 py-2',
+          'border-b border-accent-100 dark:border-accent-800',
+          'bg-accent-50 dark:bg-accent-800/50',
+          'font-medium text-accent-900 dark:text-accent-100'
+        )}
+      >
+        <FileText size={14} className="flex-shrink-0 text-blue-600 dark:text-blue-400" />
+        <span className="truncate text-xs">{displayPath}</span>
+      </div>
+
+      {/* Page info */}
+      {metadata.pageNumber && (
+        <div
+          className={cn(
+            'px-3 py-1.5',
+            'border-b border-accent-100 dark:border-accent-800',
+            'text-xs text-accent-500 dark:text-accent-400'
+          )}
+        >
+          {t('citation.page', 'Page')} {metadata.pageNumber}
+        </div>
+      )}
+
+      {/* Content */}
+      <div
+        className={cn(
+          'px-3 py-2',
+          'text-accent-700 dark:text-accent-300',
+          'leading-relaxed',
+          'overflow-y-auto'
+        )}
+        style={{ maxHeight: POPOVER_MAX_HEIGHT - 80 }} // Account for header
+      >
+        {hasContent ? (
+          <p className="whitespace-pre-wrap break-words">{metadata.content}</p>
+        ) : (
+          <p className="text-accent-400 dark:text-accent-500 italic">
+            {t('citation.noContent', 'No preview available')}
+          </p>
+        )}
+      </div>
+
+      {/* Footer hint */}
+      {metadata.pdfAvailable && (
+        <div
+          className={cn(
+            'px-3 py-1.5',
+            'border-t border-accent-100 dark:border-accent-800',
+            'text-xs text-accent-400 dark:text-accent-500',
+            'bg-accent-50/50 dark:bg-accent-800/30'
+          )}
+        >
+          {t('citation.clickToView', 'Click to view in PDF')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/citation/CitationPreview.tsx
+++ b/frontend/src/components/citation/CitationPreview.tsx
@@ -21,6 +21,8 @@ import { timing } from '../../design-system/tokens/timing';
 import type { CitationMetadata } from '../../types';
 
 interface CitationPreviewProps {
+  /** Unique ID for ARIA tooltip relationship */
+  id: string;
   metadata: CitationMetadata;
   anchorRect: DOMRect | null;
   onMouseEnter: () => void;
@@ -33,6 +35,7 @@ const POPOVER_MAX_HEIGHT = 300;
 const ESTIMATED_HEIGHT = 200; // Initial estimate for positioning
 
 export function CitationPreview({
+  id,
   metadata,
   anchorRect,
   onMouseEnter,
@@ -54,20 +57,15 @@ export function CitationPreview({
     gap: 8,
   });
 
-  // Measure actual height after render
+  // Measure actual height after render, then trigger fade-in
   useEffect(() => {
     if (popoverRef.current) {
       const height = Math.min(popoverRef.current.scrollHeight, POPOVER_MAX_HEIGHT);
       setActualHeight(height);
+      // Trigger fade-in after height measurement completes
+      requestAnimationFrame(() => setIsVisible(true));
     }
   }, [metadata.content]);
-
-  // Fade in animation
-  useEffect(() => {
-    // Small delay for DOM to settle before animation
-    const timer = setTimeout(() => setIsVisible(true), 10);
-    return () => clearTimeout(timer);
-  }, []);
 
   if (!position) return null;
 
@@ -76,6 +74,7 @@ export function CitationPreview({
 
   return (
     <div
+      id={id}
       ref={popoverRef}
       role="tooltip"
       onMouseEnter={onMouseEnter}

--- a/frontend/src/hooks/usePopoverPosition.ts
+++ b/frontend/src/hooks/usePopoverPosition.ts
@@ -4,10 +4,23 @@
  * Calculates optimal popover position relative to anchor element.
  * Automatically flips above/below based on viewport constraints.
  *
- * Usage:
- * const position = usePopoverPosition(anchorRect, 200, 320, 8);
+ * @param options - Configuration options
+ * @param options.anchorRect - DOMRect of the anchor element (null returns null)
+ * @param options.popoverHeight - Height of the popover in pixels
+ * @param options.popoverWidth - Width of the popover in pixels
+ * @param options.gap - Space between anchor and popover (default: 8px)
+ * @param options.viewportPadding - Minimum distance from viewport edges (default: 8px)
+ *
+ * @returns PopoverPosition with top, left, placement, and arrowLeft, or null if anchorRect is null
+ *
+ * @example
+ * const position = usePopoverPosition({
+ *   anchorRect: elementRef.current?.getBoundingClientRect() ?? null,
+ *   popoverHeight: 200,
+ *   popoverWidth: 320,
+ * });
  * if (position) {
- *   style={{ top: position.top, left: position.left }}
+ *   return <div style={{ top: position.top, left: position.left }} />;
  * }
  */
 
@@ -17,7 +30,8 @@ export interface PopoverPosition {
   top: number;
   left: number;
   placement: 'top' | 'bottom';
-  arrowLeft: number; // Arrow horizontal position relative to popover
+  /** Arrow horizontal position relative to popover (clamped to 12px from edges) */
+  arrowLeft: number;
 }
 
 interface UsePopoverPositionOptions {
@@ -37,6 +51,7 @@ export function usePopoverPosition({
 }: UsePopoverPositionOptions): PopoverPosition | null {
   return useMemo(() => {
     if (!anchorRect) return null;
+    if (typeof window === 'undefined') return null; // SSR guard
 
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;

--- a/frontend/src/hooks/usePopoverPosition.ts
+++ b/frontend/src/hooks/usePopoverPosition.ts
@@ -1,0 +1,79 @@
+/**
+ * Hook: usePopoverPosition
+ *
+ * Calculates optimal popover position relative to anchor element.
+ * Automatically flips above/below based on viewport constraints.
+ *
+ * Usage:
+ * const position = usePopoverPosition(anchorRect, 200, 320, 8);
+ * if (position) {
+ *   style={{ top: position.top, left: position.left }}
+ * }
+ */
+
+import { useMemo } from 'react';
+
+export interface PopoverPosition {
+  top: number;
+  left: number;
+  placement: 'top' | 'bottom';
+  arrowLeft: number; // Arrow horizontal position relative to popover
+}
+
+interface UsePopoverPositionOptions {
+  anchorRect: DOMRect | null;
+  popoverHeight: number;
+  popoverWidth: number;
+  gap?: number; // Space between anchor and popover (default: 8px)
+  viewportPadding?: number; // Minimum distance from viewport edges (default: 8px)
+}
+
+export function usePopoverPosition({
+  anchorRect,
+  popoverHeight,
+  popoverWidth,
+  gap = 8,
+  viewportPadding = 8,
+}: UsePopoverPositionOptions): PopoverPosition | null {
+  return useMemo(() => {
+    if (!anchorRect) return null;
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    // Calculate available space above and below anchor
+    const spaceBelow = viewportHeight - anchorRect.bottom - gap;
+    const spaceAbove = anchorRect.top - gap;
+
+    // Determine vertical placement: prefer below, flip to above if needed
+    const placement: 'top' | 'bottom' =
+      spaceBelow >= popoverHeight || spaceBelow >= spaceAbove ? 'bottom' : 'top';
+
+    // Calculate vertical position
+    const top =
+      placement === 'bottom'
+        ? anchorRect.bottom + gap
+        : anchorRect.top - popoverHeight - gap;
+
+    // Calculate horizontal position: center on anchor, clamp to viewport
+    const anchorCenter = anchorRect.left + anchorRect.width / 2;
+    let left = anchorCenter - popoverWidth / 2;
+
+    // Clamp to viewport edges
+    const minLeft = viewportPadding;
+    const maxLeft = viewportWidth - popoverWidth - viewportPadding;
+    left = Math.max(minLeft, Math.min(maxLeft, left));
+
+    // Calculate arrow position relative to popover
+    // Arrow should point to anchor center
+    const arrowLeft = Math.max(
+      12, // Min distance from left edge
+      Math.min(
+        popoverWidth - 12, // Max distance from left edge
+        anchorCenter - left
+      )
+    );
+
+    return { top, left, placement, arrowLeft };
+  }, [anchorRect, popoverHeight, popoverWidth, gap, viewportPadding]);
+}

--- a/frontend/src/i18n/locales/cs.json
+++ b/frontend/src/i18n/locales/cs.json
@@ -248,5 +248,13 @@
     "submitted": "Zpětná vazba odeslána",
     "thankYou": "Děkujeme za vaši zpětnou vazbu!",
     "error": "Nepodařilo se odeslat zpětnou vazbu"
+  },
+  "citation": {
+    "preview": "Náhled",
+    "source": "Zdroj",
+    "page": "Strana",
+    "section": "Sekce",
+    "noContent": "Náhled není k dispozici",
+    "clickToView": "Klikněte pro zobrazení v PDF"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -246,5 +246,13 @@
     "submitted": "Feedback submitted",
     "thankYou": "Thank you for your feedback!",
     "error": "Failed to submit feedback"
+  },
+  "citation": {
+    "preview": "Preview",
+    "source": "Source",
+    "page": "Page",
+    "section": "Section",
+    "noContent": "No preview available",
+    "clickToView": "Click to view in PDF"
   }
 }


### PR DESCRIPTION
## Summary
- Replace native HTML title tooltip on citation badges with rich hover preview showing full paragraph text
- Add automatic viewport-aware positioning (flips above/below based on available space)
- Preview stays open when hovering the preview itself (debounced mouse events)
- Add i18n translations for preview UI text (Czech/English)

## Test plan
- [ ] Hover over a citation badge in a conversation - preview should appear after 200ms
- [ ] Move cursor away - preview should disappear after 100ms
- [ ] Move cursor to preview itself - preview should stay open
- [ ] Test near viewport edges - preview should flip above if no space below
- [ ] Test dark mode - preview should have proper dark styling
- [ ] Test with long content - preview should scroll with max-height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hoverable citation previews with floating popovers that auto-position and respect reduced-motion.
  * New positioning logic for popovers to flip and clamp placement based on viewport.
  * Added citation UI text in English and Czech.

* **Bug Fixes**
  * Improved conversation/message fetching to reliably request JSON responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->